### PR TITLE
fix: don't assert anonymous queues when there is a binding

### DIFF
--- a/src/haredo-chain.ts
+++ b/src/haredo-chain.ts
@@ -392,17 +392,9 @@ export class HaredoChain<T = unknown> {
             return;
         }
         if (this.state.queue) {
-            if (this.state.queue.anonymous && this.state.queue.isPerishable()) {
-                this.connectionManager.emitter.once('connectionclose', () => {
-                    debug('Clearing name for queue', this.state.queue);
-                    this.state.queue.name = '';
-                });
-            }
-            if (!(this.state.queue.name || '').startsWith('amq.')) {
-                debug(`Asserting ${this.state.queue}`);
-                await this.connectionManager.assertQueue(this.state.queue);
-                debug(`Done asserting ${this.state.queue}`);
-            }
+            debug(`Asserting ${this.state.queue}`);
+            await this.connectionManager.assertQueue(this.state.queue);
+            debug(`Done asserting ${this.state.queue}`);
         }
         await promiseMap(this.state.exchanges, async (exchangery) => {
             debug(`Asserting ${exchangery.exchange}`);

--- a/test/integration/consumer.test.ts
+++ b/test/integration/consumer.test.ts
@@ -96,7 +96,7 @@ describe('Consumer', () => {
     it('should clear an anonymous queue name when connection is reestablished', async () => {
         const queue = new Queue('').exclusive();
         expect(queue.isPerishable()).to.be.true;
-        await haredo.queue(queue).subscribe(msg => {});
+        await haredo.queue(queue).exchange('test').subscribe(msg => {});
         const originalName = queue.name;
         await delay(50);
         await connection.close();


### PR DESCRIPTION
closes #13